### PR TITLE
Remove spclient.wg.spotify.com

### DIFF
--- a/StreamingAds/hosts
+++ b/StreamingAds/hosts
@@ -42,7 +42,6 @@
 0.0.0.0 securepubads.g.doubleclick.net
 0.0.0.0 seen-on-screen.thewhizmarketing.com
 0.0.0.0 server-54-230-216-203.mrs50.r.cloudfront.net
-0.0.0.0 spclient.wg.spotify.com
 0.0.0.0 tpc.googlesyndication.com
 0.0.0.0 tracking.tidalhifi.com
 0.0.0.0 u.scdn.co


### PR DESCRIPTION
Blocking spclient.wg.spotify.com breaks playback (and prevents login).